### PR TITLE
Adding missing flutter_clock_helper dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_clock_helper:
-    path: ../flutter_clock_helper
+    git:
+      url: git://github.com/flutter/flutter_clock.git
+      path: flutter_clock_helper
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#1 Using `flutter_clock_helper` from the official github repo